### PR TITLE
TASK00 Egor Shalashnov SPbU

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,9 +1,12 @@
 #include <CL/cl.h>
 #include <libclew/ocl_init.h>
 
+#include <cstddef>
 #include <iostream>
 #include <sstream>
 #include <stdexcept>
+#include <string>
+#include <type_traits>
 #include <vector>
 
 template<typename T>
@@ -27,6 +30,30 @@ void reportError(cl_int err, const std::string &filename, int line)
 }
 
 #define OCL_SAFE_CALL(expr) reportError(expr, __FILE__, __LINE__)
+
+template<typename T>
+static void print_device_info(cl_device_id device, cl_device_info param_name,
+                              const char *attr_name)
+{
+	T value{};
+	if constexpr (std::is_same_v<T, std::string>)
+	{
+		size_t size = 0;
+		OCL_SAFE_CALL(clGetDeviceInfo(device, param_name, 0, nullptr, &size));
+		value.resize(size);
+		OCL_SAFE_CALL(clGetDeviceInfo(device, param_name, size, value.data(), nullptr));
+
+		if (!value.empty() && value.back() == '\0')
+			value.pop_back();
+	}
+	else
+	{
+		OCL_SAFE_CALL(clGetDeviceInfo(device, param_name, sizeof(value), &value, nullptr));
+	}
+
+	std::cout << "            " << attr_name << ": " << value << std::endl;
+}
+
 
 int main()
 {
@@ -70,16 +97,30 @@ int main()
 		// TODO 1.2
 		// Аналогично тому, как был запрошен список идентификаторов всех платформ - так и с названием платформы, теперь, когда известна длина названия - его можно запросить:
 		std::vector<unsigned char> platformName(platformNameSize, 0);
-		// clGetPlatformInfo(...);
+		OCL_SAFE_CALL(clGetPlatformInfo(platform, CL_PLATFORM_NAME, platformNameSize, platformName.data(), NULL));
 		std::cout << "    Platform name: " << platformName.data() << std::endl;
+
+
 
 		// TODO 1.3
 		// Запросите и напечатайте так же в консоль вендора данной платформы
 
+		size_t platformVendorSize = 0;
+		OCL_SAFE_CALL(clGetPlatformInfo(platform, CL_PLATFORM_VENDOR, 0, nullptr, &platformVendorSize));
+
+		std::vector<unsigned char> platformVendor(platformVendorSize, 0);
+
+		OCL_SAFE_CALL(clGetPlatformInfo(platform, CL_PLATFORM_VENDOR, platformVendorSize, platformVendor.data(), NULL));
+		std::cout << "    Platform vendor: " << platformVendor.data() << std::endl;
+ 
 		// TODO 2.1
 		// Запросите число доступных устройств данной платформы (аналогично тому, как это было сделано для запроса числа доступных платформ - см. секцию "OpenCL Runtime" -> "Query Devices")
 		cl_uint devicesCount = 0;
+		OCL_SAFE_CALL(clGetDeviceIDs(platform, CL_DEVICE_TYPE_ALL, 0, NULL, &devicesCount));
+		std::cout << "        Number of " << platformName.data()  << " devices: " << devicesCount << std::endl;
 
+		std::vector<cl_device_id> devices(devicesCount);
+		OCL_SAFE_CALL(clGetDeviceIDs(platform, CL_DEVICE_TYPE_ALL, devicesCount, devices.data(), NULL));
 		for(int deviceIndex = 0; deviceIndex < devicesCount; ++deviceIndex)
 		{
 			// TODO 2.2
@@ -88,6 +129,15 @@ int main()
 			// - Тип устройства (видеокарта/процессор/что-то странное)
 			// - Размер памяти устройства в мегабайтах
 			// - Еще пару или более свойств устройства, которые вам покажутся наиболее интересными
+			print_device_info<std::string>(devices[deviceIndex], CL_DEVICE_NAME, "DEVICE NAME");
+			print_device_info<cl_device_type>(devices[deviceIndex], CL_DEVICE_TYPE, "DEVICE TYPE");
+			
+			cl_ulong memory = 0;
+			OCL_SAFE_CALL(clGetDeviceInfo(devices[deviceIndex], CL_DEVICE_GLOBAL_MEM_SIZE, sizeof(memory), &memory, nullptr));
+			std::cout << "            MEMORY SIZE: "<< memory / (1024.0 * 1024.0) << " MiB" << std::endl;
+
+			print_device_info<std::string>(devices[deviceIndex], CL_DEVICE_VERSION, "DEVICE VERSION");
+			print_device_info<std::string>(devices[deviceIndex], CL_DRIVER_VERSION, "DRIVER VERSION");
 		}
 	}
 


### PR DESCRIPTION
<details><summary>Локальный вывод</summary>
<pre>
Number of OpenCL platforms: 2
Platform #1/2
    Platform name: Intel(R) OpenCL
    Platform vendor: Intel(R) Corporation
        Number of Intel(R) OpenCL devices: 1
            DEVICE NAME: AMD Ryzen 5 5500U with Radeon Graphics         
            DEVICE TYPE: 2
            MEMORY SIZE: 7304.91 MiB
            DEVICE VERSION: OpenCL 3.0 (Build 0)
            DRIVER VERSION: 2026.21.7.0.24_160000
Platform #2/2
    Platform name: rusticl
    Platform vendor: Mesa/X.org
        Number of rusticl devices: 1
            DEVICE NAME: AMD Radeon Graphics (radeonsi, renoir, ACO, DRM 3.64, 6.19.14-108.fc42.x86_64)
            DEVICE TYPE: 4
            MEMORY SIZE: 512 MiB
            DEVICE VERSION: OpenCL 3.0 
            DRIVER VERSION: 25.1.9
</pre>
</details>

<details><summary>Вывод Github CI</summary>
<pre>
Number of OpenCL platforms: 1
Platform #1/1
    Platform name: Intel(R) OpenCL
    Platform vendor: Intel(R) Corporation
        Number of Intel(R) OpenCL devices: 1
            DEVICE NAME: AMD EPYC 9V45 96-Core Processor                
            DEVICE TYPE: 2
            MEMORY SIZE: 15989.7 MiB
            DEVICE VERSION: OpenCL 3.0 (Build 0)
            DRIVER VERSION: 2026.21.7.0.24_160000
</pre>
</details>